### PR TITLE
Fixed some tests that would not pass, fixed some shellcheck warnings, used shellformat to format script

### DIFF
--- a/log.sh
+++ b/log.sh
@@ -1,138 +1,142 @@
 #!/bin/bash
 
-set -uo pipefail;
+set -uo pipefail
+
+script_name=$(basename "$0")
 
 function _log_exception() {
-  (
-    BASHLOG_FILE=0;
-    BASHLOG_JSON=0;
-    BASHLOG_SYSLOG=0;
+	(
+		BASHLOG_FILE=0
+		BASHLOG_JSON=0
+		BASHLOG_SYSLOG=0
 
-    log 'error' "Logging Exception: ${@}";
-  );
+		log 'error' "Logging Exception: ${*}"
+	)
 }
 
 function log() {
-  local date_format="${BASHLOG_DATE_FORMAT:-+%F %T}";
-  local date="$(date "${date_format}")";
-  local date_s="$(date "+%s")";
+	local date_format="${BASHLOG_DATE_FORMAT:-+%F %T}"
+	local date="$(date "${date_format}")"
+	local date_s="$(date "+%s")"
 
-  local file="${BASHLOG_FILE:-0}";
-  local file_path="${BASHLOG_FILE_PATH:-/tmp/$(basename "${0}").log}";
+	local file="${BASHLOG_FILE:-0}"
+	local file_path="${BASHLOG_FILE_PATH:-/tmp/${script_name}.log}"
 
-  local json="${BASHLOG_JSON:-0}";
-  local json_path="${BASHLOG_JSON_PATH:-/tmp/$(basename "${0}").log.json}";
+	local json="${BASHLOG_JSON:-0}"
+	local json_path="${BASHLOG_JSON_PATH:-/tmp/${script_name}.log.json}"
 
-  local syslog="${BASHLOG_SYSLOG:-0}";
-  local tag="${BASHLOG_SYSLOG_TAG:-$(basename "${0}")}";
-  local facility="${BASHLOG_SYSLOG_FACILITY:-local0}";
-  local pid="${$}";
+	local syslog="${BASHLOG_SYSLOG:-0}"
+	local tag="${BASHLOG_SYSLOG_TAG:-${script_name}}"
+	local facility="${BASHLOG_SYSLOG_FACILITY:-local0}"
+	local pid="$$"
 
-  local level="${1}";
-  local upper="$(echo "${level}" | awk '{print toupper($0)}')";
-  local debug_level="${DEBUG:-0}";
+	local level="$1"
+	local upper="${level^^}" # Bash natively can set variable to uppercase instead of calling other methods
+	local debug_level="${DEBUG:-0}"
 
-  shift 1;
+	shift 1
 
-  local line="${@}";
+	local line="${*}"
 
-  # RFC 5424
-  #
-  # Numerical         Severity
-  #   Code
-  #
-  #    0       Emergency: system is unusable
-  #    1       Alert: action must be taken immediately
-  #    2       Critical: critical conditions
-  #    3       Error: error conditions
-  #    4       Warning: warning conditions
-  #    5       Notice: normal but significant condition
-  #    6       Informational: informational messages
-  #    7       Debug: debug-level messages
+	# RFC 5424
+	#
+	# Numerical         Severity
+	#   Code
+	#
+	#    0       Emergency: system is unusable
+	#    1       Alert: action must be taken immediately
+	#    2       Critical: critical conditions
+	#    3       Error: error conditions
+	#    4       Warning: warning conditions
+	#    5       Notice: normal but significant condition
+	#    6       Informational: informational messages
+	#    7       Debug: debug-level messages
 
-  local -A severities;
-  severities['DEBUG']=7;
-  severities['INFO']=6;
-  severities['NOTICE']=5; # Unused
-  severities['WARN']=4;
-  severities['ERROR']=3;
-  severities['CRIT']=2;   # Unused
-  severities['ALERT']=1;  # Unused
-  severities['EMERG']=0;  # Unused
+	local -A severities
+	severities['DEBUG']=7
+	severities['INFO']=6
+	severities['NOTICE']=5 # Unused
+	severities['WARN']=4
+	severities['ERROR']=3
+	severities['CRIT']=2  # Unused
+	severities['ALERT']=1 # Unused
+	severities['EMERG']=0 # Unused
 
-  local severity="${severities[${upper}]:-3}"
+	local severity="${severities[${upper}]:-3}"
 
-  if [ "${debug_level}" -gt 0 ] || [ "${severity}" -lt 7 ]; then
+	if [ "${debug_level}" -gt 0 ] || [ "${severity}" -lt 7 ]; then
 
-    if [ "${syslog}" -eq 1 ]; then
-      local syslog_line="${upper}: ${line}";
+		if [ "${syslog}" -eq 1 ]; then
+			local syslog_line="${upper}: ${line}"
 
-      logger \
-        --id="${pid}" \
-        -t "${tag}" \
-        -p "${facility}.${severity}" \
-        "${syslog_line}" \
-        || _log_exception "logger --id=\"${pid}\" -t \"${tag}\" -p \"${facility}.${severity}\" \"${syslog_line}\"";
-    fi;
+			logger \
+				--id="${pid}" \
+				-t "${tag}" \
+				-p "${facility}.${severity}" \
+				"${syslog_line}" ||
+				_log_exception "logger --id=\"${pid}\" -t \"${tag}\" -p \"${facility}.${severity}\" \"${syslog_line}\""
+		fi
 
-    if [ "${file}" -eq 1 ]; then
-      local file_line="${date} [${upper}] ${line}";
-      echo -e "${file_line}" >> "${file_path}" \
-        || _log_exception "echo -e \"${file_line}\" >> \"${file_path}\"";
-    fi;
+		if [ "${file}" -eq 1 ]; then
+			local file_line="${date} [${upper}] ${line}"
+			echo -e "${file_line}" >>"${file_path}" ||
+				_log_exception "echo -e \"${file_line}\" >> \"${file_path}\""
+		fi
 
-    if [ "${json}" -eq 1 ]; then
-      local json_line="$(printf '{"timestamp":"%s","level":"%s","message":"%s"}' "${date_s}" "${level}" "${line}")";
-      echo -e "${json_line}" >> "${json_path}" \
-        || _log_exception "echo -e \"${json_line}\" >> \"${json_path}\"";
-    fi;
+		if [ "${json}" -eq 1 ]; then
+			# don't use printf anymore to speed up just a little
+			local json_line="{\"timestamp\":\"${date_s}\",\"level\":\"${level}\",\"message\":\"${line}\"}"
+			echo -e "${json_line}" >>"${json_path}" ||
+				_log_exception "echo -e \"${json_line}\" >> \"${json_path}\""
+		fi
 
-  fi;
+	fi
 
-  local -A colours;
-  colours['DEBUG']='\033[34m'  # Blue
-  colours['INFO']='\033[32m'   # Green
-  colours['NOTICE']=''         # Unused
-  colours['WARN']='\033[33m'   # Yellow
-  colours['ERROR']='\033[31m'  # Red
-  colours['CRIT']=''           # Unused
-  colours['ALERT']=''          # Unused
-  colours['EMERG']=''          # Unused
-  colours['DEFAULT']='\033[0m' # Default
+	local -A colours
+	colours['DEBUG']='\033[34m'  # Blue
+	colours['INFO']='\033[32m'   # Green
+	colours['NOTICE']=''         # Unused
+	colours['WARN']='\033[33m'   # Yellow
+	colours['ERROR']='\033[31m'  # Red
+	colours['CRIT']=''           # Unused
+	colours['ALERT']=''          # Unused
+	colours['EMERG']=''          # Unused
+	colours['DEFAULT']='\033[0m' # Default
 
-  local norm="${colours['DEFAULT']}";
-  local colour="${colours[${upper}]:-\033[31m}";
+	local norm="${colours['DEFAULT']}"
+	local colour="${colours[${upper}]:-\033[31m}"
 
-  local std_line="${colour}${date} [${upper}] ${line}${norm}";
+	local std_line="${colour}${date} [${upper}] ${line}${norm}"
 
-  # Standard Output (Pretty)
-  case "${level}" in
-    'info'|'warn')
-      echo -e "${std_line}";
-      ;;
-    'debug')
-      if [ "${debug_level}" -gt 0 ]; then
-        echo -e "${std_line}";
-      fi;
-      ;;
-    'error')
-      echo -e "${std_line}" >&2;
-      if [ "${debug_level}" -gt 0 ]; then
-        echo -e "Here's a shell to debug with. 'exit 0' to continue. Other exit codes will abort - parent shell will terminate.";
-        bash || exit "${?}";
-      fi;
-      ;;
-    *)
-      log 'error' "Undefined log level trying to log: ${@}";
-      ;;
-  esac
+	# Standard Output (Pretty)
+	case "${level}" in
+		'info' | 'warn')
+			echo -e "${std_line}"
+			;;
+		'debug')
+			if [ "${debug_level}" -gt 0 ]; then
+				echo -e "${std_line}"
+			fi
+			;;
+		'error')
+			echo -e "${std_line}" >&2
+			if [ "${debug_level}" -gt 0 ]; then
+				echo -e "Here's a shell to debug with. 'exit 0' to continue. Other exit codes will abort - parent shell will terminate."
+				bash || exit "${?}"
+			fi
+			;;
+		*)
+			log 'error' "Undefined log level trying to log: ${*}"
+			;;
+	esac
 }
 
-declare prev_cmd="null";
-declare this_cmd="null";
-trap 'prev_cmd=$this_cmd; this_cmd=$BASH_COMMAND' DEBUG \
-  && log debug 'DEBUG trap set' \
-  || log error 'DEBUG trap failed to set';
+# shellcheck disable=SC2034
+declare prev_cmd="null"
+declare this_cmd="null"
+trap 'prev_cmd=$this_cmd; this_cmd=$BASH_COMMAND' DEBUG &&
+	log debug 'DEBUG trap set' ||
+	log error 'DEBUG trap failed to set'
 
 # This is an option if you want to log every single command executed,
 # but it will significantly impact script performance and unit tests will fail

--- a/test.sh
+++ b/test.sh
@@ -1,441 +1,466 @@
 #!/bin/bash
 
-set -uo pipefail;
+set -uo pipefail
 
 # Interactive debug testing is off by default.
 # To turn it on, pass TEST_INTERACTIVE=1
 # Correct exit code from this test script
 # will then be '1' instead of '0'
-declare interactive="${TEST_INTERACTIVE:-0}";
+script_name=$(basename "${0}")
+readonly script_name
 
-function result() {
-  local level="${1}";
-  shift;
-  local line="${@}"; 
+declare interactive="${TEST_INTERACTIVE:-0}"
 
-  case "${level}" in
-    ok)
-      echo -e "\t\033[32mOK: ${line}\033[0m";
-      ;;
-    fail)
-      echo -e "\t\033[31mFAIL: ${line}\033[0m";
-      echo -e "Abandoning tests due to failure";
-      exit 1;
-      ;;
-    *)
-      echo "UWOTM8?!";
-      exit 1;
-      ;;
-  esac;
+readonly logfile="/tmp/${script_name}.log"
+readonly logfile_json="/tmp/${script_name}.log.json"
+touch "${logfile}"
+touch "${logfile_json}"
+
+if [ -f "/var/log/messages" ]; then
+	syslogoutfile=/var/log/messages
+elif [ -f "/var/log/syslog" ]; then
+	syslogoutfile=/var/log/syslog
+else
+	exit 1
+fi
+
+if [ -f "/var/log/debug" ]; then
+	syslogdebugoutfile=/var/log/debug
+elif [ -f "/var/log/syslog" ]; then
+	syslogdebugoutfile=/var/log/syslog
+else
+	exit 1
+fi
+
+readonly syslogoutfile
+
+delete_temp_logfiles() {
+	rm -f "${logfile}"
+	rm -f "${logfile_json}"
 }
 
-sudo rm -f "/tmp/${0}.log";
-sudo rm -f "/tmp/${0}.log.json";
+trap 'delete_temp_logfiles' EXIT
 
-source log.sh;
+function result() {
+	local level="${1}"
+	shift
+	local line="${@}"
 
-declare random_string="$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)";
-declare stdout;
-declare fileout;
-declare jsonout;
-declare syslogout;
+	case "${level}" in
+		ok)
+			echo -e "\t\033[32mOK: ${line}\033[0m"
+			;;
+		fail)
+			echo -e "\t\033[31mFAIL: ${line}\033[0m"
+			echo -e "Test failed, continuing remaining tests"
+			return 1
+			;;
+		*)
+			echo "UWOTM8?!"
+			exit 1
+			;;
+	esac
+}
 
-declare BASHLOG_FILE=1;
-declare BASHLOG_JSON=1;
-declare BASHLOG_SYSLOG=1;
+# shellcheck source-path=SCRIPTDIR
+source log.sh
+
+declare random_string
+# shellcheck disable=SC2002
+random_string="$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)"
+readonly random_string
+declare stdout
+declare fileout
+declare jsonout
+declare syslogout
+
+declare BASHLOG_FILE=1
+declare BASHLOG_JSON=1
+declare BASHLOG_SYSLOG=1
 
 ##
 # INFO
 ##
 
-echo "Testing 'info'";
+echo "Testing 'info'"
 
-rm -f "/tmp/${0}.log";
-rm -f "/tmp/${0}.log.json";
+BASHLOG_FILE=1
+BASHLOG_JSON=1
+BASHLOG_SYSLOG=1
+DEBUG=0
 
-BASHLOG_FILE=1;
-BASHLOG_JSON=1;
-BASHLOG_SYSLOG=1;
-DEBUG=0;
+stdout="$(log 'info' "${random_string}")"
+fileout="$(tail -n1 "${logfile}")"
+jsonout="$(tail -n1 "${logfile_json}")"
+syslogout="$(sudo tail -n1 "${syslogoutfile}")"
 
-stdout="$(log 'info' "${random_string}")";
-fileout="$(tail -n1 /tmp/${0}.log)";
-jsonout="$(tail -n1 /tmp/${0}.log.json)";
-syslogout="$(sudo tail -n1 /var/log/messages)";
+grep -q -E $'^\033\[32m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[INFO\] '"${random_string}"$'\033\[0m$' <<<"${stdout}" &&
+	result ok 'info -> stdout' ||
+	result fail 'info -> stdout'
 
-grep -q -E $'^\033\[32m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[INFO\] '"${random_string}"$'\033\[0m$' <<<"${stdout}" \
-  && result ok 'info -> stdout' \
-  || result fail 'info -> stdout';
+grep -q -E "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[INFO\] ${random_string}$" <<<"${fileout}" &&
+	result ok 'info -> file' ||
+	result fail 'info -> file'
 
-grep -q -E "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[INFO\] ${random_string}$" <<<"${fileout}" \
-  && result ok 'info -> file' \
-  || result fail 'info -> file';
+grep -q -E '^{"timestamp":"[0-9]{10}","level":"info","message":"'"${random_string}"'"}$' <<<"${jsonout}" &&
+	result ok 'info -> json file' ||
+	result fail 'info -> json file'
 
-grep -q -E '^{"timestamp":"[0-9]{10}","level":"info","message":"'"${random_string}"'"}$' <<<"${jsonout}" \
-  && result ok 'info -> json file' \
-  || result fail 'info -> json file';
-
-grep -q -E "$(basename ${0})\[${$}\]: INFO: ${random_string}$" <<<"${syslogout}" \
-  && result ok 'info -> syslog (/var/log/messages)' \
-  || result fail 'info -> syslog (/var/log/messages)';
+grep -q -E "${script_name}\[${$}\]: INFO: ${random_string}$" <<<"${syslogout}" &&
+	result ok "info -> syslog (\"${syslogoutfile}\")" ||
+	result fail "info -> syslog (\"${syslogoutfile}\")"
 
 ##
 # WARN
 ##
 
-echo "Testing 'warn'";
+echo "Testing 'warn'"
 
-rm -f "/tmp/${0}.log";
-rm -f "/tmp/${0}.log.json";
+delete_temp_logfiles
 
-BASHLOG_FILE=1;
-BASHLOG_JSON=1;
-BASHLOG_SYSLOG=1;
-DEBUG=0;
+BASHLOG_FILE=1
+BASHLOG_JSON=1
+BASHLOG_SYSLOG=1
+DEBUG=0
 
-stdout="$(log 'warn' "${random_string}")";
-fileout="$(tail -n1 /tmp/${0}.log)";
-jsonout="$(tail -n1 /tmp/${0}.log.json)";
-syslogout="$(sudo tail -n1 /var/log/syslog)";
+stdout="$(log 'warn' "${random_string}")"
+fileout="$(tail -n1 "${logfile}")"
+jsonout="$(tail -n1 "${logfile_json}")"
+syslogout="$(sudo tail -n1 /var/log/syslog)"
 
-grep -q -E $'^\033\[33m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[WARN\] '"${random_string}"$'\033\[0m$' <<<"${stdout}" \
-  && result ok 'warn -> stdout' \
-  || result fail 'warn -> stdout';
+grep -q -E $'^\033\[33m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[WARN\] '"${random_string}"$'\033\[0m$' <<<"${stdout}" &&
+	result ok 'warn -> stdout' ||
+	result fail 'warn -> stdout'
 
-grep -q -E "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[WARN\] ${random_string}$" <<<"${fileout}" \
-  && result ok 'warn -> file' \
-  || result fail 'warn -> file';
+grep -q -E "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[WARN\] ${random_string}$" <<<"${fileout}" &&
+	result ok 'warn -> file' ||
+	result fail 'warn -> file'
 
-grep -q -E '^{"timestamp":"[0-9]{10}","level":"warn","message":"'"${random_string}"'"}$' <<<"${jsonout}" \
-  && result ok 'warn -> json file' \
-  || result fail 'warn -> json file';
+grep -q -E '^{"timestamp":"[0-9]{10}","level":"warn","message":"'"${random_string}"'"}$' <<<"${jsonout}" &&
+	result ok 'warn -> json file' ||
+	result fail 'warn -> json file'
 
-grep -q -E "$(basename ${0})\[${$}\]: WARN: ${random_string}$" <<<"${syslogout}" \
-  && result ok 'warn -> syslog (/var/log/syslog)' \
-  || result fail 'warn -> syslog (/var/log/syslog)';
+grep -q -E "${script_name}\[${$}\]: WARN: ${random_string}$" <<<"${syslogout}" &&
+	result ok 'warn -> syslog (/var/log/syslog)' ||
+	result fail 'warn -> syslog (/var/log/syslog)'
 
 ##
 # ERROR
 ##
 
-echo "Testing: 'error'";
+echo "Testing: 'error'"
 
-rm -f "/tmp/${0}.log";
-rm -f "/tmp/${0}.log.json";
+delete_temp_logfiles
 
-BASHLOG_FILE=1;
-BASHLOG_JSON=1;
-BASHLOG_SYSLOG=1;
-DEBUG=0;
+BASHLOG_FILE=1
+BASHLOG_JSON=1
+BASHLOG_SYSLOG=1
+DEBUG=0
 
-stderr="$(log 'error' "${random_string}" 2>&1 1>/dev/null)";
-fileout="$(tail -n1 /tmp/${0}.log)";
-jsonout="$(tail -n1 /tmp/${0}.log.json)";
-syslogout="$(sudo tail -n1 /var/log/syslog)";
+stderr="$(log 'error' "${random_string}" 2>&1 1>/dev/null)"
+fileout="$(tail -n1 "${logfile}")"
+jsonout="$(tail -n1 "${logfile_json}")"
+syslogout="$(sudo tail -n1 /var/log/syslog)"
 
-grep -q -E $'^\033\[31m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] '"${random_string}"$'\033\[0m$' <<<"${stderr}" \
-  && result ok 'error -> stderr' \
-  || result fail 'error -> stderr';
+grep -q -E $'^\033\[31m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] '"${random_string}"$'\033\[0m$' <<<"${stderr}" &&
+	result ok 'error -> stderr' ||
+	result fail 'error -> stderr'
 
-grep -q -E "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] ${random_string}$" <<<"${fileout}" \
-  && result ok 'error -> file' \
-  || result fail 'error -> file';
+grep -q -E "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] ${random_string}$" <<<"${fileout}" &&
+	result ok 'error -> file' ||
+	result fail 'error -> file'
 
-grep -q -E '^{"timestamp":"[0-9]{10}","level":"error","message":"'"${random_string}"'"}$' <<<"${jsonout}" \
-  && result ok 'error -> json file' \
-  || result fail 'error -> json file';
+grep -q -E '^{"timestamp":"[0-9]{10}","level":"error","message":"'"${random_string}"'"}$' <<<"${jsonout}" &&
+	result ok 'error -> json file' ||
+	result fail 'error -> json file'
 
-grep -q -E "$(basename ${0})\[${$}\]: ERROR: ${random_string}$" <<<"${syslogout}" \
-  && result ok 'error -> syslog (/var/log/syslog)' \
-  || result fail 'error -> syslog (/var/log/syslog)';
+grep -q -E "${script_name}\[${$}\]: ERROR: ${random_string}$" <<<"${syslogout}" &&
+	result ok 'error -> syslog (/var/log/syslog)' ||
+	result fail 'error -> syslog (/var/log/syslog)'
 
 ##
 # DEBUG OFF
 ##
 
-echo "Testing 'debug', DEBUG=0";
+echo "Testing 'debug', DEBUG=0"
 
-rm -f "/tmp/${0}.log";
-rm -f "/tmp/${0}.log.json";
+delete_temp_logfiles
 
-BASHLOG_FILE=1;
-BASHLOG_JSON=1;
-BASHLOG_SYSLOG=1;
-DEBUG=0;
+BASHLOG_FILE=1
+BASHLOG_JSON=1
+BASHLOG_SYSLOG=1
+DEBUG=0
 
 # If there's no output, there'll be no file
-touch "/tmp/${0}.log";
-touch "/tmp/${0}.log.json";
+touch "${logfile}"
+touch "${logfile_json}"
 
-stdout="$(log 'debug' "${random_string}")";
-fileout="$(tail -n1 /tmp/${0}.log)";
-jsonout="$(tail -n1 /tmp/${0}.log.json)";
-syslogout="$(sudo tail -n1 /var/log/debug)";
+stdout="$(log 'debug' "${random_string}")"
+fileout="$(tail -n1 "${logfile}")"
+jsonout="$(tail -n1 "${logfile_json}")"
+syslogout="$(sudo tail -n1 "${syslogdebugoutfile}")"
 
-grep -q -E $'^\033\[34m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[DEBUG\] '"${random_string}"$'\033\[0m$' <<<"${stdout}" \
-  && result fail 'debug -> stdout' \
-  || result ok 'debug -> stdout';
+grep -q -E $'^\033\[34m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[DEBUG\] '"${random_string}"$'\033\[0m$' <<<"${stdout}" &&
+	result fail 'debug -> stdout' ||
+	result ok 'debug -> stdout'
 
-grep -q -E "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[DEBUG\] ${random_string}$" <<<"${fileout}" \
-  && result fail 'debug -> file' \
-  || result ok 'debug -> file';
+grep -q -E "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[DEBUG\] ${random_string}$" <<<"${fileout}" &&
+	result fail 'debug -> file' ||
+	result ok 'debug -> file'
 
-grep -q -E '^{"timestamp":"[0-9]{10}","level":"debug","message":"'"${random_string}"'"}$' <<<"${jsonout}" \
-  && result fail 'debug -> json file' \
-  || result ok 'debug -> json file';
+grep -q -E '^{"timestamp":"[0-9]{10}","level":"debug","message":"'"${random_string}"'"}$' <<<"${jsonout}" &&
+	result fail 'debug -> json file' ||
+	result ok 'debug -> json file'
 
-grep -q -E "$(basename ${0})\[${$}\]: DEBUG: ${random_string}$" <<<"${syslogout}" \
-  && result fail 'debug -> syslog (/var/log/debug)' \
-  || result ok 'debug -> syslog (/var/log/debug)';
+grep -q -E "${script_name}\[${$}\]: DEBUG: ${random_string}$" <<<"${syslogout}" &&
+	result fail "debug -> syslog (\"${syslogoutfile}\")" ||
+	result ok "debug -> syslog (\"${syslogdebugoutfile}\")"
 
 ##
 # DEBUG ON
 ##
 
-echo "Testing 'debug', DEBUG=1";
+echo "Testing 'debug', DEBUG=1"
 
-rm -f "/tmp/${0}.log";
-rm -f "/tmp/${0}.log.json";
+delete_temp_logfiles
 
-BASHLOG_FILE=1;
-BASHLOG_JSON=1;
-BASHLOG_SYSLOG=1;
-DEBUG=1;
+BASHLOG_FILE=1
+BASHLOG_JSON=1
+BASHLOG_SYSLOG=1
+DEBUG=1
 
-stdout="$(log 'debug' "${random_string}")";
-fileout="$(tail -n1 /tmp/${0}.log)";
-jsonout="$(tail -n1 /tmp/${0}.log.json)";
-syslogout="$(sudo tail -n1 /var/log/debug)";
+stdout="$(log 'debug' "${random_string}")"
+fileout="$(tail -n1 "${logfile}")"
+jsonout="$(tail -n1 "${logfile_json}")"
+syslogout="$(sudo tail -n1 "${syslogdebugoutfile}")"
 
-grep -q -E $'^\033\[34m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[DEBUG\] '"${random_string}"$'\033\[0m$' <<<"${stdout}" \
-  && result ok 'debug -> stdout' \
-  || result fail 'debug -> stdout';
+grep -q -E $'^\033\[34m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[DEBUG\] '"${random_string}"$'\033\[0m$' <<<"${stdout}" &&
+	result ok 'debug -> stdout' ||
+	result fail 'debug -> stdout'
 
-grep -q -E "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[DEBUG\] ${random_string}$" <<<"${fileout}" \
-  && result ok 'debug -> file' \
-  || result fail 'debug -> file';
+grep -q -E "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[DEBUG\] ${random_string}$" <<<"${fileout}" &&
+	result ok 'debug -> file' ||
+	result fail 'debug -> file'
 
-grep -q -E '^{"timestamp":"[0-9]{10}","level":"debug","message":"'"${random_string}"'"}$' <<<"${jsonout}" \
-  && result ok 'debug -> json file' \
-  || result fail 'debug -> json file';
+grep -q -E '^{"timestamp":"[0-9]{10}","level":"debug","message":"'"${random_string}"'"}$' <<<"${jsonout}" &&
+	result ok 'debug -> json file' ||
+	result fail 'debug -> json file'
 
-grep -q -E "$(basename ${0})\[${$}\]: DEBUG: ${random_string}$" <<<"${syslogout}" \
-  && result ok 'debug -> syslog (/var/log/debug)' \
-  || result fail 'debug -> syslog (/var/log/debug)';
+grep -q -E "${script_name}\[${$}\]: DEBUG: ${random_string}$" <<<"${syslogout}" &&
+	result ok "debug -> syslog (\"${syslogoutfile}\")" ||
+	result fail "debug -> syslog (\"${syslogoutfile}\")"
 
 ##
 # BAD LEVEL, DEBUG OFF
 ##
 
-echo "Testing: BAD LEVEL ('snooch'), DEBUG=0";
+echo "Testing: BAD LEVEL ('snooch'), DEBUG=0"
 
-rm -f "/tmp/${0}.log";
-rm -f "/tmp/${0}.log.json";
+delete_temp_logfiles
 
-BASHLOG_FILE=1;
-BASHLOG_JSON=1;
-BASHLOG_SYSLOG=1;
-DEBUG=0;
+BASHLOG_FILE=1
+BASHLOG_JSON=1
+BASHLOG_SYSLOG=1
+DEBUG=0
 
-stderr="$(log 'snooch' "${random_string}" 2>&1 1>/dev/null)";
-fileout="$(tail -n1 /tmp/${0}.log)";
-jsonout="$(tail -n1 /tmp/${0}.log.json)";
-syslogout="$(sudo tail -n1 /var/log/syslog)";
+stderr="$(log 'snooch' "${random_string}" 2>&1 1>/dev/null)"
+fileout="$(tail -n1 "${logfile}")"
+jsonout="$(tail -n1 "${logfile_json}")"
+syslogout="$(sudo tail -n1 /var/log/syslog)"
 
-grep -q -E $'^\033\[31m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] Undefined log level trying to log: '"${random_string}"$'\033\[0m$' <<<"${stderr}" \
-  && result ok 'snooch -> stderr' \
-  || result fail 'snooch -> stderr';
+grep -q -E $'^\033\[31m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] Undefined log level trying to log: '"${random_string}"$'\033\[0m$' <<<"${stderr}" &&
+	result ok 'snooch -> stderr' ||
+	result fail 'snooch -> stderr'
 
-grep -q -E "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] Undefined log level trying to log: ${random_string}$" <<<"${fileout}" \
-  && result ok 'snooch -> file' \
-  || result fail 'snooch -> file';
+grep -q -E "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] Undefined log level trying to log: ${random_string}$" <<<"${fileout}" &&
+	result ok 'snooch -> file' ||
+	result fail 'snooch -> file'
 
-grep -q -E '^{"timestamp":"[0-9]{10}","level":"error","message":"Undefined log level trying to log: '"${random_string}"'"}$' <<<"${jsonout}" \
-  && result ok 'snooch -> json file' \
-  || result fail 'snooch -> json file';
+grep -q -E '^{"timestamp":"[0-9]{10}","level":"error","message":"Undefined log level trying to log: '"${random_string}"'"}$' <<<"${jsonout}" &&
+	result ok 'snooch -> json file' ||
+	result fail 'snooch -> json file'
 
-grep -q -E "$(basename ${0})\[${$}\]: ERROR: Undefined log level trying to log: ${random_string}$" <<<"${syslogout}" \
-  && result ok 'snooch -> syslog (/var/log/syslog)' \
-  || result fail 'snooch -> syslog (/var/log/syslog)';
+grep -q -E "${script_name}\[${$}\]: ERROR: Undefined log level trying to log: ${random_string}$" <<<"${syslogout}" &&
+	result ok 'snooch -> syslog (/var/log/syslog)' ||
+	result fail 'snooch -> syslog (/var/log/syslog)'
 
 ##
 # BAD LEVEL, DEBUG ON
 ##
 
-echo "Testing: BAD LEVEL ('snooch'), DEBUG=1";
+echo "Testing: BAD LEVEL ('snooch'), DEBUG=1"
 
-rm -f "/tmp/${0}.log";
-rm -f "/tmp/${0}.log.json";
+delete_temp_logfiles
 
-BASHLOG_FILE=1;
-BASHLOG_JSON=1;
-BASHLOG_SYSLOG=1;
-DEBUG=1;
+BASHLOG_FILE=1
+BASHLOG_JSON=1
+BASHLOG_SYSLOG=1
+DEBUG=1
 
-stderr="$(echo | log 'snooch' "${random_string}" 2>&1 1>/dev/null)";
-fileout="$(tail -n1 /tmp/${0}.log)";
-jsonout="$(tail -n1 /tmp/${0}.log.json)";
-syslogout="$(sudo tail -n1 /var/log/syslog)";
+stderr="$(echo | log 'snooch' "${random_string}" 2>&1 1>/dev/null)"
+fileout="$(tail -n1 "${logfile}")"
+jsonout="$(tail -n1 "${logfile_json}")"
+syslogout="$(sudo tail -n1 /var/log/syslog)"
 
-grep -q -E $'^\033\[31m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] Undefined log level trying to log: '"${random_string}"$'\033\[0m$' <<<"${stderr}" \
-  && result ok 'snooch -> stderr' \
-  || result fail 'snooch -> stderr';
+grep -q -E $'^\033\[31m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] Undefined log level trying to log: '"${random_string}"$'\033\[0m$' <<<"${stderr}" &&
+	result ok 'snooch -> stderr' ||
+	result fail 'snooch -> stderr'
 
-grep -q -E "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] Undefined log level trying to log: ${random_string}$" <<<"${fileout}" \
-  && result ok 'snooch -> file' \
-  || result fail 'snooch -> file';
+grep -q -E "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] Undefined log level trying to log: ${random_string}$" <<<"${fileout}" &&
+	result ok 'snooch -> file' ||
+	result fail 'snooch -> file'
 
-grep -q -E '^{"timestamp":"[0-9]{10}","level":"error","message":"Undefined log level trying to log: '"${random_string}"'"}$' <<<"${jsonout}" \
-  && result ok 'snooch -> json file' \
-  || result fail 'snooch -> json file';
+grep -q -E '^{"timestamp":"[0-9]{10}","level":"error","message":"Undefined log level trying to log: '"${random_string}"'"}$' <<<"${jsonout}" &&
+	result ok 'snooch -> json file' ||
+	result fail 'snooch -> json file'
 
-grep -q -E "$(basename ${0})\[${$}\]: ERROR: Undefined log level trying to log: ${random_string}$" <<<"${syslogout}" \
-  && result ok 'snooch -> syslog (/var/log/syslog)' \
-  || result fail 'snooch -> syslog (/var/log/syslog)';
+grep -q -E "${script_name}\[${$}\]: ERROR: Undefined log level trying to log: ${random_string}$" <<<"${syslogout}" &&
+	result ok 'snooch -> syslog (/var/log/syslog)' ||
+	result fail 'snooch -> syslog (/var/log/syslog)'
 
 ##
 # INFO, FILE IO EXCEPTION, DEBUG OFF
 ##
 
-echo "Testing: 'info', IO Exception (file), DEBUG=0";
+echo "Testing: 'info', IO Exception (file), DEBUG=0"
 
-rm -f "/tmp/${0}.log";
+rm -f "${logfile}"
 
-BASHLOG_FILE=1;
-BASHLOG_JSON=0;
-BASHLOG_SYSLOG=0;
-DEBUG=0;
+BASHLOG_FILE=1
+BASHLOG_JSON=0
+BASHLOG_SYSLOG=0
+DEBUG=0
 
-sudo touch "/tmp/${0}.log";
+sudo touch "${logfile}"
 
-stderr="$(log 'info' "${random_string}" 2>&1 1>/dev/null)";
+stderr="$(log 'info' "${random_string}" 2>&1 1>/dev/null)"
 
-sudo rm -f "/tmp/${0}.log";
+sudo rm -f "${logfile}"
 
-grep -q -E $'^./log.sh: line [0-9]+: /tmp/'"$(basename ${0})"'.log: Permission denied' <<<"${stderr}" \
-  && grep -q -E $'\033\[31m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] Logging Exception: echo -e "[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[INFO\] '"${random_string}"'" >> "/tmp/'"$(basename ${0})"$'.log"\033\[0m$' <<<"${stderr}" \
-  && result ok 'info -> file, Permission denied -> stderr' \
-  || result fail 'info -> file, Permission denied -> stderr';
+grep -q -E $"^log.sh: line [0-9]+: ${logfile}: Permission denied" <<<"${stderr}" &&
+	grep -q -E $'\033\[31m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] Logging Exception: echo -e "[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[INFO\] '"${random_string}"'" >> "/tmp/'"${script_name}"$'.log"\033\[0m$' <<<"${stderr}" &&
+	result ok 'info -> file, Permission denied -> stderr' ||
+	result fail 'info -> file, Permission denied -> stderr'
 
 ##
 # INFO, FILE IO EXCEPTION, DEBUG ON
 ##
 
-echo "Testing: 'info', IO Exception (file), DEBUG=1";
+echo "Testing: 'info', IO Exception (file), DEBUG=1"
 
-rm -f "/tmp/${0}.log";
+rm -f "${logfile}"
 
-BASHLOG_FILE=1;
-BASHLOG_JSON=0;
-BASHLOG_SYSLOG=0;
-DEBUG=1;
+BASHLOG_FILE=1
+BASHLOG_JSON=0
+BASHLOG_SYSLOG=0
+DEBUG=1
 
-sudo touch "/tmp/${0}.log";
+sudo touch "${logfile}"
 
-stderr="$(echo | log 'info' "${random_string}" 2>&1 1>/dev/null)";
+stderr="$(echo | log 'info' "${random_string}" 2>&1 1>/dev/null)"
 
-sudo rm -f "/tmp/${0}.log";
+sudo rm -f "${logfile}"
 
-grep -q -E $'^./log.sh: line [0-9]+: /tmp/'"$(basename ${0})"'.log: Permission denied' <<<"${stderr}" \
-  && grep -q -E $'\033\[31m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] Logging Exception: echo -e "[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[INFO\] '"${random_string}"'" >> "/tmp/'"$(basename ${0})"$'.log"\033\[0m$' <<<"${stderr}" \
-  && result ok 'info -> file, Permission denied -> stderr' \
-  || result fail 'info -> file, Permission denied -> stderr';
+grep -q -E $"^log.sh: line [0-9]+: ${logfile}: Permission denied" <<<"${stderr}" &&
+	grep -q -E $'\033\[31m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] Logging Exception: echo -e "[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[INFO\] '"${random_string}"'" >> "/tmp/'"${script_name}"$'.log"\033\[0m$' <<<"${stderr}" &&
+	result ok 'info -> file, Permission denied -> stderr' ||
+	result fail 'info -> file, Permission denied -> stderr'
 
 ##
 # INFO, JSON FILE IO EXCEPTION, DEBUG OFF
 ##
 
-echo "Testing: 'info', IO Exception (json), DEBUG=0";
+echo "Testing: 'info', IO Exception (json), DEBUG=0"
 
-rm -f "/tmp/${0}.log.json";
+rm -f "${logfile_json}"
 
-BASHLOG_FILE=0;
-BASHLOG_JSON=1;
-BASHLOG_SYSLOG=0;
-DEBUG=0;
+BASHLOG_FILE=0
+BASHLOG_JSON=1
+BASHLOG_SYSLOG=0
+DEBUG=0
 
-sudo touch "/tmp/${0}.log.json";
+sudo touch "${logfile_json}"
 
-stderr="$(log 'info' "${random_string}" 2>&1 1>/dev/null)";
+stderr="$(log 'info' "${random_string}" 2>&1 1>/dev/null)"
 
-sudo rm -f "/tmp/${0}.log.json";
+sudo rm -f "${logfile_json}"
 
-grep -q -E $'^./log.sh: line [0-9]+: /tmp/'"$(basename ${0})"'.log.json: Permission denied' <<<"${stderr}" \
-  && grep -q -E $'\033\[31m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] Logging Exception: echo -e "{"timestamp":"[0-9]{10}","level":"info","message":"'"${random_string}"'"}" >> "/tmp/'"$(basename ${0})"$'.log.json"\033\[0m$' <<<"${stderr}" \
-  && result ok 'info -> file, Permission denied -> stderr' \
-  || result fail 'info -> file, Permission denied -> stderr';
+grep -q -E $"^log.sh: line [0-9]+: ${logfile_json}: Permission denied" <<<"${stderr}" &&
+	grep -q -E $'\033\[31m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] Logging Exception: echo -e "{"timestamp":"[0-9]{10}","level":"info","message":"'"${random_string}"'"}" >> "/tmp/'"${script_name}"$'.log.json"\033\[0m$' <<<"${stderr}" &&
+	result ok 'info -> file, Permission denied -> stderr' ||
+	result fail 'info -> file, Permission denied -> stderr'
 
 ##
 # INFO, JSON FILE IO EXCEPTION, DEBUG ON
 ##
 
-echo "Testing: 'info', IO Exception (json), DEBUG=1";
+echo "Testing: 'info', IO Exception (json), DEBUG=1"
 
-rm -f "/tmp/${0}.log.json";
+rm -f "${logfile_json}"
 
-BASHLOG_FILE=0;
-BASHLOG_JSON=1;
-BASHLOG_SYSLOG=0;
-DEBUG=1;
+BASHLOG_FILE=0
+BASHLOG_JSON=1
+BASHLOG_SYSLOG=0
+DEBUG=1
 
-sudo touch "/tmp/${0}.log.json";
+sudo touch "${logfile_json}"
 
-stderr="$(echo | log 'info' "${random_string}" 2>&1 1>/dev/null)";
+stderr="$(echo | log 'info' "${random_string}" 2>&1 1>/dev/null)"
 
-sudo rm -f "/tmp/${0}.log.json";
+sudo rm -f "${logfile_json}"
 
-grep -q -E $'^./log.sh: line [0-9]+: /tmp/'"$(basename ${0})"'.log.json: Permission denied' <<<"${stderr}" \
-  && grep -q -E $'\033\[31m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] Logging Exception: echo -e "{"timestamp":"[0-9]{10}","level":"info","message":"'"${random_string}"'"}" >> "/tmp/'"$(basename ${0})"$'.log.json"\033\[0m$' <<<"${stderr}" \
-  && result ok 'info -> file, Permission denied -> stderr' \
-  || result fail 'info -> file, Permission denied -> stderr';
+grep -q -E $"^log.sh: line [0-9]+: ${logfile_json}: Permission denied" <<<"${stderr}" &&
+	grep -q -E $'\033\[31m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] Logging Exception: echo -e "{"timestamp":"[0-9]{10}","level":"info","message":"'"${random_string}"'"}" >> "/tmp/'"${script_name}"$'.log.json"\033\[0m$' <<<"${stderr}" &&
+	result ok 'info -> file, Permission denied -> stderr' ||
+	result fail 'info -> file, Permission denied -> stderr'
 
 ##
 # WARN, FILE IO EXCEPTION, DEBUG OFF
 ##
 
-echo "Testing: 'warn', IO Exception (file), DEBUG=0";
+echo "Testing: 'warn', IO Exception (file), DEBUG=0"
 
-rm -f "/tmp/${0}.log";
+rm -f "${logfile}"
 
-BASHLOG_FILE=1;
-BASHLOG_JSON=0;
-BASHLOG_SYSLOG=0;
-DEBUG=0;
+BASHLOG_FILE=1
+BASHLOG_JSON=0
+BASHLOG_SYSLOG=0
+DEBUG=0
 
-sudo touch "/tmp/${0}.log";
+sudo touch "${logfile}"
 
-stderr="$(log 'warn' "${random_string}" 2>&1 1>/dev/null)";
+stderr="$(log 'warn' "${random_string}" 2>&1 1>/dev/null)"
 
-sudo rm -f "/tmp/${0}.log";
+sudo rm -f "${logfile}"
 
-grep -q -E $'^./log.sh: line [0-9]+: /tmp/'"$(basename ${0})"'.log: Permission denied' <<<"${stderr}" \
-  && grep -q -E $'\033\[31m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] Logging Exception: echo -e "[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[WARN\] '"${random_string}"'" >> "/tmp/'"$(basename ${0})"$'.log"\033\[0m$' <<<"${stderr}" \
-  && result ok 'warn -> file, Permission denied -> stderr' \
-  || result fail 'warn -> file, Permission denied -> stderr';
+grep -q -E $"^log.sh: line [0-9]+: ${logfile}: Permission denied" <<<"${stderr}" &&
+	grep -q -E $'\033\[31m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] Logging Exception: echo -e "[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[WARN\] '"${random_string}"'" >> "/tmp/'"${script_name}"$'.log"\033\[0m$' <<<"${stderr}" &&
+	result ok 'warn -> file, Permission denied -> stderr' ||
+	result fail 'warn -> file, Permission denied -> stderr'
 
 ##
 # ERROR, FILE IO EXCEPTION, DEBUG OFF
 ##
 
-echo "Testing: 'error', IO Exception (file), DEBUG=0";
+echo "Testing: 'error', IO Exception (file), DEBUG=0"
 
-rm -f "/tmp/${0}.log";
+rm -f "${logfile}"
 
-BASHLOG_FILE=1;
-BASHLOG_JSON=0;
-BASHLOG_SYSLOG=0;
-DEBUG=0;
+BASHLOG_FILE=1
+BASHLOG_JSON=0
+BASHLOG_SYSLOG=0
+DEBUG=0
 
-sudo touch "/tmp/${0}.log";
+sudo touch "${logfile}"
 
-stderr="$(log 'error' "${random_string}" 2>&1 1>/dev/null)";
+stderr="$(log 'error' "${random_string}" 2>&1 1>/dev/null)"
 
-sudo rm -f "/tmp/${0}.log";
+sudo rm -f "${logfile}"
 
-grep -q -E $'^./log.sh: line [0-9]+: /tmp/'"$(basename ${0})"'.log: Permission denied' <<<"${stderr}" \
-  && grep -q -E $'\033\[31m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] Logging Exception: echo -e "[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] '"${random_string}"'" >> "/tmp/'"$(basename ${0})"$'.log"\033\[0m$' <<<"${stderr}" \
-  && result ok 'error -> file, Permission denied -> stderr' \
-  || result fail 'error -> file, Permission denied -> stderr';
+grep -q -E $"^log.sh: line [0-9]+: ${logfile}: Permission denied" <<<"${stderr}" &&
+	grep -q -E $'\033\[31m[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] Logging Exception: echo -e "[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} \[ERROR\] '"${random_string}"'" >> "/tmp/'"${script_name}"$'.log"\033\[0m$' <<<"${stderr}" &&
+	result ok 'error -> file, Permission denied -> stderr' ||
+	result fail 'error -> file, Permission denied -> stderr'
 
 ##
 # INTERACTIVE DEBUG
@@ -443,26 +468,26 @@ grep -q -E $'^./log.sh: line [0-9]+: /tmp/'"$(basename ${0})"'.log: Permission d
 
 if [ "${interactive}" -eq 1 ]; then
 
-  echo "Testing: Debug Interaction, DEBUG=1";
+	echo "Testing: Debug Interaction, DEBUG=1"
 
-  BASHLOG_FILE=0;
-  BASHLOG_JSON=0;
-  BASHLOG_SYSLOG=0;
-  DEBUG=1;
+	BASHLOG_FILE=0
+	BASHLOG_JSON=0
+	BASHLOG_SYSLOG=0
+	DEBUG=1
 
-  echo -e "\n\t\033[32mLogging a normal successful debug message to stdout\033[0m";
-  log 'debug' 'A normal successful debug message';
+	echo -e "\n\t\033[32mLogging a normal successful debug message to stdout\033[0m"
+	log 'debug' 'A normal successful debug message'
 
-  echo -e "\n\t\033[32mLogging an error message to stdout that should provide a debug shell\n\tExit the shell with ^D, 'exit 0' or 'exit'.\n\tIf you exit with a non-zero code, testing will be abandoned, this script will exit without further warning.\033[0m";
-  log 'error' 'An error message';
+	echo -e "\n\t\033[32mLogging an error message to stdout that should provide a debug shell\n\tExit the shell with ^D, 'exit 0' or 'exit'.\n\tIf you exit with a non-zero code, testing will be abandoned, this script will exit without further warning.\033[0m"
+	log 'error' 'An error message'
 
-  result ok 'Interactive Shell. We have errored and continued.';
+	result ok 'Interactive Shell. We have errored and continued.'
 
-  echo -e "\n\t\033[32mLogging an error message to stdout that should provide a debug shell\n\tExit the shell with 'exit 1' or a non-zero code of your choice.\n\tThe test is successful if this script exits with the same code\033[0m";
-  log 'error' 'An error message';
+	echo -e "\n\t\033[32mLogging an error message to stdout that should provide a debug shell\n\tExit the shell with 'exit 1' or a non-zero code of your choice.\n\tThe test is successful if this script exits with the same code\033[0m"
+	log 'error' 'An error message'
 
-  result fail 'Interactive Shell. This script should have exited with a non-zero code';
+	result fail 'Interactive Shell. This script should have exited with a non-zero code'
 
-fi;
+fi
 
-exit 0;
+exit 0


### PR DESCRIPTION
* Updated some failing tests (namely the json file tests, which were incorrectly looking for the non-json log file)
* Parameterized the script name instead of running $(basename 0) everywhere
* Parameterized the logfile paths for the regular .log and the json ones (maybe would be useful in the future, probably not)
* Add a test to determine if /var/log/message and /var/log/debug exists, if not, default to using /var/log/syslog (many Linux distros do not have the aforementioned paths anymore, unless you change your syslog config, namely Ubuntu and Linux Mint)
* changed logging function from using printf to just using bash variable substitution (log.sh line 88), presumably there could a be a very slight performance gain by not calling printf
* Change process id from ${$} to $$
* Fixed some issues that shellcheck reports when linting script
* Ran shellformat to cleanup code formatting

I appreciate this logging framework, thank you much! 

I apologize for the massive diff due to running shellformat. It's a great plugin that I use to keep all my scripts clean and tidy. 